### PR TITLE
Implement Websocket Connection Tracking

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -1,13 +1,15 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/drew138/tictac/api/endpoints"
 	"github.com/drew138/tictac/api/websockets"
 	"github.com/gorilla/mux"
 )
 
 // RegisterRoutes applies specified routes to fiber app
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, dependencies *struct{}) {
 	// GET Endpoints
 
 	// POST Endpoints
@@ -19,5 +21,7 @@ func RegisterRoutes(r *mux.Router) {
 	// PATCH Endpoints
 	r.HandleFunc("/api/v1/changepass/", endpoints.ChangePassword).Methods("PATCH")
 	// Websocket Endpoints
-	r.HandleFunc("/ws/v1/tictactoe", websockets.HandleConnection)
+	r.HandleFunc("/ws/v1/tictactoe", func(w http.ResponseWriter, r *http.Request) {
+		websockets.HandleConnection(w, r, dependencies.WebsocketConnections)
+	})
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -3,13 +3,15 @@ package api
 import (
 	"net/http"
 
+	"github.com/drew138/tictac/dependencies"
+
 	"github.com/drew138/tictac/api/endpoints"
 	"github.com/drew138/tictac/api/websockets"
 	"github.com/gorilla/mux"
 )
 
 // RegisterRoutes applies specified routes to fiber app
-func RegisterRoutes(r *mux.Router, dependencies *struct{}) {
+func RegisterRoutes(r *mux.Router, dependencies *dependencies.Dependencies) {
 	// GET Endpoints
 
 	// POST Endpoints

--- a/api/websockets/connections/connections.go
+++ b/api/websockets/connections/connections.go
@@ -33,9 +33,6 @@ func (c *Connections) startConnectionsWorker() {
 			delete(c.connectedUsers, id)
 			log.Println("Removed user", id, "from connection pool")
 			break
-		default:
-			log.Println("Unrecognized message sent to connection worker")
-			break
 		}
 	}
 }

--- a/api/websockets/connections/connections.go
+++ b/api/websockets/connections/connections.go
@@ -1,0 +1,41 @@
+package connections
+
+import (
+	"log"
+)
+
+// Connections holds channels for interacting with connection pool of users
+type Connections struct {
+	Connect        chan string
+	Disconnect     chan string
+	connectedUsers map[string]bool
+}
+
+// StartConnectionTracking starts connection workers and returns Connections struct
+func StartConnectionTracking() *Connections {
+	connectionPool := Connections{
+		Connect:        make(chan string),
+		Disconnect:     make(chan string),
+		connectedUsers: make(map[string]bool),
+	}
+	go connectionPool.startConnectionsWorker()
+	return &connectionPool
+}
+
+func (c *Connections) startConnectionsWorker() {
+	for {
+		select {
+		case id := <-c.Connect:
+			c.connectedUsers[id] = true
+			log.Println("Added user", id, "to connection pool")
+			break
+		case id := <-c.Disconnect:
+			delete(c.connectedUsers, id)
+			log.Println("Removed user", id, "from connection pool")
+			break
+		default:
+			log.Println("Unrecognized message sent to connection worker")
+			break
+		}
+	}
+}

--- a/api/websockets/messages/tictactoe/messages.go
+++ b/api/websockets/messages/tictactoe/messages.go
@@ -7,4 +7,6 @@ import (
 // Message is base message for tictactoe messaging
 type Message struct {
 	messages.Message
+	UserID string `json:"userID"`
+	RoomID string `json:"roomID"`
 }

--- a/api/websockets/tictactoe.go
+++ b/api/websockets/tictactoe.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/drew138/tictac/api/websockets/connections"
+
 	messages "github.com/drew138/tictac/api/websockets/messages/tictactoe"
 	"github.com/gorilla/websocket"
 )
@@ -17,17 +19,17 @@ var upgrader = websocket.Upgrader{
 }
 
 // HandleConnection handles initial websocket connection
-func HandleConnection(w http.ResponseWriter, r *http.Request) {
+func HandleConnection(w http.ResponseWriter, r *http.Request, c connections.Connections) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Fatal("Error upgrading websocket connection: ", err.Error())
 		w.WriteHeader(400)
 		json.NewEncoder(w).Encode(&map[string]string{"Error": err.Error()})
 	}
-	go handleMessages(conn)
+	go handleMessages(conn, &c)
 }
 
-func handleMessages(conn *websocket.Conn) error {
+func handleMessages(conn *websocket.Conn, c *connections.Connections) error {
 	log.Println("Websocket connection established.")
 	defer func() {
 		if err := conn.Close(); err != nil {

--- a/api/websockets/tictactoe.go
+++ b/api/websockets/tictactoe.go
@@ -33,6 +33,7 @@ func handleMessages(conn *websocket.Conn, c *connections.Connections) error {
 	log.Println("Websocket connection established.")
 	defer func() {
 		if err := conn.Close(); err != nil {
+			// TODO: Remove UserID from connection pool
 			log.Fatalln("Failed to close websocket connection: ", err.Error())
 		} else {
 			log.Println("Websocket connection closed.")

--- a/api/websockets/tictactoe.go
+++ b/api/websockets/tictactoe.go
@@ -19,14 +19,14 @@ var upgrader = websocket.Upgrader{
 }
 
 // HandleConnection handles initial websocket connection
-func HandleConnection(w http.ResponseWriter, r *http.Request, c connections.Connections) {
+func HandleConnection(w http.ResponseWriter, r *http.Request, c *connections.Connections) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Fatal("Error upgrading websocket connection: ", err.Error())
 		w.WriteHeader(400)
 		json.NewEncoder(w).Encode(&map[string]string{"Error": err.Error()})
 	}
-	go handleMessages(conn, &c)
+	go handleMessages(conn, c)
 }
 
 func handleMessages(conn *websocket.Conn, c *connections.Connections) error {

--- a/api/websockets/tictactoe.go
+++ b/api/websockets/tictactoe.go
@@ -46,6 +46,17 @@ func handleMessages(conn *websocket.Conn, c *connections.Connections) error {
 		}
 		j, _ := json.Marshal(newMessage)
 		log.Println("Message Recieved: ", string(j))
+		switch newMessage.Action {
+		case "connect":
+			c.Connect <- newMessage.UserID
+			break
+		case "disconnect":
+			c.Disconnect <- newMessage.UserID
+			break
+		default:
+			log.Println("Unknown message recieved: ", string(j))
+			break
+		}
 	}
 }
 

--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -1,0 +1,10 @@
+package dependencies
+
+import (
+	"github.com/drew138/tictac/api/websockets/connections"
+)
+
+// Dependencies holds all dependencies required by project
+type Dependencies struct {
+	WebsocketConnections *connections.Connections
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/drew138/tictac/api"
+	"github.com/drew138/tictac/api/websockets/connections"
 	"github.com/drew138/tictac/database"
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
@@ -19,10 +20,12 @@ func loadEnv() {
 }
 
 func main() {
+	var dependencies struct{}
 	loadEnv()
 	database.AutoMigrateDB()
+	dependencies.WebsocketConnections = connections.StartConnectionTracking()
 	r := mux.NewRouter()
-	api.RegisterRoutes(r)
+	api.RegisterRoutes(r, &dependencies)
 	log.Println("Server started, running on port 8080.")
 	if err := http.ListenAndServe("127.0.0.1:8080", r); err != nil {
 		log.Fatal("Server failed to start: ", err.Error())

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/drew138/tictac/dependencies"
 	"log"
 	"net/http"
+
+	"github.com/drew138/tictac/dependencies"
 
 	"github.com/drew138/tictac/api"
 	"github.com/drew138/tictac/api/websockets/connections"
@@ -21,7 +22,7 @@ func loadEnv() {
 }
 
 func main() {
-	var dependencies dependencies.Dependencies{}
+	var dependencies dependencies.Dependencies
 	// Load dependencies
 	loadEnv()
 	database.AutoMigrateDB()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/drew138/tictac/dependencies"
 	"log"
 	"net/http"
 
@@ -20,7 +21,7 @@ func loadEnv() {
 }
 
 func main() {
-	var dependencies struct{}
+	var dependencies dependencies.Dependencies{}
 	// Load dependencies
 	loadEnv()
 	database.AutoMigrateDB()

--- a/main.go
+++ b/main.go
@@ -21,9 +21,11 @@ func loadEnv() {
 
 func main() {
 	var dependencies struct{}
+	// Load dependencies
 	loadEnv()
 	database.AutoMigrateDB()
 	dependencies.WebsocketConnections = connections.StartConnectionTracking()
+	// Mount services
 	r := mux.NewRouter()
 	api.RegisterRoutes(r, &dependencies)
 	log.Println("Server started, running on port 8080.")


### PR DESCRIPTION
On the server, we need a way to track which users are connected to the server through the websocket
- added module to track connected users using a set
- added a worker to add and remove connected users to and from the set
- added a dependencies module to track dependencies required for the server

Remaining problems:
- server closes when client unexpectedly closes websocket connection, need to find out why and implement fix
- need to remove users from connection tracking when they ungracefully kill the websocket connection